### PR TITLE
GS 40 & 41 compatibility.

### DIFF
--- a/src/extension.js
+++ b/src/extension.js
@@ -8,12 +8,12 @@ function init() {
 function enable() {
     // Make caribou resize windows to not cover them
     Main.layoutManager.removeChrome(Main.layoutManager.keyboardBox);
-    Main.layoutManager.addChrome(   Main.layoutManager.keyboardBox, { affectsStruts: true, trackFullscreen: true });
+    Main.layoutManager.addTopChrome(   Main.layoutManager.keyboardBox, { affectsStruts: true, trackFullscreen: true });
 
 }
 
 function disable() {
     // Revert: Make caribou resize windows to not cover them
     Main.layoutManager.removeChrome(Main.layoutManager.keyboardBox);
-    Main.layoutManager.addChrome(   Main.layoutManager.keyboardBox);
+    Main.layoutManager.addTopChrome(   Main.layoutManager.keyboardBox);
 }

--- a/src/metadata.json
+++ b/src/metadata.json
@@ -1,1 +1,1 @@
-{"name": "caribou-resize-workspace", "uuid": "caribou-resize-workspace@simon.schumann.web.de", "description": "Resizes the workspace when Gnome's virual keyboard caribou appears so that it doesn't cover the window the user wants to type in.", "shell-version": ["3.18", "3.20"]}
+{"name": "caribou-resize-workspace", "uuid": "caribou-resize-workspace@simon.schumann.web.de", "description": "Resizes the workspace when Gnome's virual keyboard caribou appears so that it doesn't cover the window the user wants to type in.", "shell-version": ["40", "41"]}


### PR DESCRIPTION
Use LayoutManager.addTopChrome() for readding the keyboard box, changed in GS40.